### PR TITLE
Update navbar.json to include sponsors

### DIFF
--- a/data/navbar.json
+++ b/data/navbar.json
@@ -27,9 +27,18 @@
   {
     "name": "Call for Speakers",
     "path": "/call-for-speakers",
+    "visible": false
+  },
+  {
+    "name": "Sponsors",
+    "path": "/#sponsors",
     "visible": true
   },
-
+  {
+    "name": "Sponsor Us",
+    "path": "/sponsor-us",
+    "visible": false
+  },
   {
     "name": "Arcade",
     "path": "/arcade",


### PR DESCRIPTION
Fixes #29 and adds `sponsor-us` to navbar but hidden